### PR TITLE
Hotfix related to integration (Windows).

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ were come up and developed in the
 
 Now, you can download this repository and manually integrate
 `Logger` into your project.
-* Import `logger.hpp` and `macro.hpp`, where you want to use `Logger`;
+* Import `log.hpp`, where you want to use `Logger`;
 * Write your first log:
     ```C++
-    #include "logger.hpp"
-    #include "macro.hpp"
+    #include "log.hpp"
     
     int main() {
-        logger::Logger::init(logger::info, "../log");
+        logger::init(logger::info, "../log");
   
         LOG(logger::info) << "Hello, world!";
         LOGI << "Short form";

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -34,10 +34,10 @@ public:
         auto itt = SysClock::to_time_t(timestamp_) + Time::timezone() * SEC_IN_HOUR;
         std::ostringstream ss;
         if (is_ISO_format)
-            ss << std::put_time(gmtime(&itt), "%FT%T.")
+            ss << std::put_time(gmtime(&itt), "%Y-%m-%dT%H:%M:%S.")
                << std::setw(3) << std::setfill('0') << ms << "Z";
         else
-            ss << std::put_time(gmtime(&itt), "%F %T.")
+            ss << std::put_time(gmtime(&itt), "%Y-%m-%d %H:%M:%S.")
                << std::setw(3) << std::setfill('0') << ms;
         return ss.str();
     }
@@ -67,7 +67,7 @@ std::string get_dirname(const fs::path& path) {
     if (path.string().empty())
         return "";
     if (fs::exists(path))
-        return fs::canonical(path).filename();
+        return fs::canonical(path).filename().string();
 
     auto str = path.string();
     unsigned length = str.length();


### PR DESCRIPTION
- Add explicit convertation from path to string in `utils::get_dirname()` method;
- Fix specificators for `put_time`;
- Fix `README.md` listing in the 'How to use' paragraph.