### PR TITLE
Add target for building library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,5 +6,8 @@ set(CMAKE_CXX_STANDARD 17)
 include_directories(include)
 include_directories(include/appenders)
 include_directories(include/formatters)
+add_library(liblogger src/main.cpp)
+set_target_properties(liblogger PROPERTIES PREFIX "")
+target_include_directories(liblogger PUBLIC include include/appenders include/formatters)
 add_executable(logger
         src/main.cpp)


### PR DESCRIPTION
Now for using logger in other projects developers needs to manually download your repository. This PR adds new target to your `CMakeLists.txt` for building static library. So now we can use something like
```cmake
FetchContent_Declare( 
    logger,
    GIT_REPOSITORY https://github.com/temikfart/logger.git
    GIT_TAG main
)
FetchContent_MakeAvailable(logger)
...
target_link_library(my_project PRIVATE liblogger)
```
in `CMakeLists.txt`, and then
```c++
#include <log.hpp>
...
```
in header files.