### PR TITLE
[#15] Remove warnings during compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,10 @@ set(CMAKE_CXX_STANDARD 17)
 include_directories(include)
 include_directories(include/appenders)
 include_directories(include/formatters)
+
 add_library(liblogger src/main.cpp)
 set_target_properties(liblogger PROPERTIES PREFIX "")
 target_include_directories(liblogger PUBLIC include include/appenders include/formatters)
+
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror")
 add_executable(logger src/main.cpp)

--- a/include/logger/appenders/appender_interface.hpp
+++ b/include/logger/appenders/appender_interface.hpp
@@ -16,12 +16,13 @@ enum AppenderType {
 class IAppender {
 public:
     IAppender(AppenderType type) : appender_type_(type) {}
-    IAppender(AppenderType type, Severity severity) : appender_type_(type), severity_(severity) {}
+    IAppender(AppenderType type, Severity severity) : severity_(severity), appender_type_(type) {}
+    virtual ~IAppender() = default;
     virtual void write(const Record& record) = 0;
     Severity severity() const { return severity_; }
     void set_severity(Severity severity) { severity_ = severity; }
     AppenderType type() const { return appender_type_; }
-    virtual void set_colours(Severity severity, const MessageColours& msg_cols) {}
+    virtual void set_colours(Severity /*unused*/, const MessageColours& /*unused*/) {}
     virtual void turn_colours_on() {}
     virtual void turn_colours_off() {}
 //    virtual ~IAppender(); // TODO: See Vladimirov's lectures


### PR DESCRIPTION
Fixes #15.

- Added new compilation flags `-Wextra -Wall -Werror` to force fix all warnings;
- Fixed existed warnings.